### PR TITLE
Fixing bug when normalizing the json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Users should check the repositories they want to be webhooked by `Spelling CI`. 
 ```
 {
   "extensions" : ["txt", "other"],
-  "ignore_words" : ["word1", "word2],
+  "ignore_words" : ["word1", "word2"],
   "ignore_patterns" : ["regex1", "regex2"],
   "ignore_blocks" : [{"open" : "open_regex", "close" : "close_regex"}]
 }

--- a/src/spellingci_config.erl
+++ b/src/spellingci_config.erl
@@ -49,7 +49,18 @@ normalize_extensions(Config) ->
 
 -spec normalize_sheldon_config(map()) -> sheldon_config:config().
 normalize_sheldon_config(Config) ->
-  SheldonConfig = maps:get(sheldon_config, Config, sheldon_config:default()),
+  IgnoreWords = maps:get(<<"ignore_words">>, Config, []),
+  IgnoreBlocks = maps:get(<<"ignore_blocks">>, Config, []),
+  NormalizeBlocksFun = fun(#{<<"open">> := Open, <<"close">> := Close}) ->
+    #{open => Open, close => Close}
+  end,
+  SheldonConfig = #{ ignore_words    =>
+                       lists:map(fun binary_to_list/1, IgnoreWords)
+                   , ignore_patterns =>
+                       maps:get(<<"ignore_patterns">>, Config, [])
+                   , ignore_blocks   =>
+                       lists:map(NormalizeBlocksFun, IgnoreBlocks)
+                   },
   sheldon_config:normalize(SheldonConfig).
 
 -spec default_extensions() -> [binary()].

--- a/test/files/sample1.json
+++ b/test/files/sample1.json
@@ -1,0 +1,3 @@
+{
+  "extensions" : ["txt", "other"]
+}

--- a/test/files/sample2.json
+++ b/test/files/sample2.json
@@ -1,0 +1,6 @@
+{
+  "extensions" : ["txt", "other"],
+  "ignore_words" : ["word1", "word2"],
+  "ignore_patterns" : ["regex1", "regex2"],
+  "ignore_blocks" : [{"open" : "open_regex", "close" : "close_regex"}]
+}


### PR DESCRIPTION
The sheldon config wasn't be generated properly after normalizing spellingci.json file.